### PR TITLE
fix!: generate and parse as utf8 lengths

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -61,6 +61,8 @@ test('patch api', () => {
         [DIFF_INSERT, 'to'],
         [DIFF_EQUAL, ' thi'],
       ],
+      byteLength1: 8,
+      byteLength2: 6,
       length1: 8,
       length2: 6,
       start1: 0,

--- a/src/patch/__tests__/make.test.ts
+++ b/src/patch/__tests__/make.test.ts
@@ -64,6 +64,18 @@ describe('make', () => {
     )
   })
 
+  test('Unicode character encoding', () => {
+    const patches = make('Dette blir gøy.', 'Dette blir kjipt.')
+    expect(stringify(patches)).toMatchInlineSnapshot(`
+      "@@ -8,9 +8,10 @@
+       lir 
+      -g%C3%B8y
+      +kjipt
+       .
+      "
+    `)
+  })
+
   test('Long string with repeats', () => {
     let textA = ''
     for (let x = 0; x < 100; x++) {

--- a/src/patch/__tests__/stringify_parse.test.ts
+++ b/src/patch/__tests__/stringify_parse.test.ts
@@ -16,7 +16,9 @@ test('stringifyPatch', () => {
   // Patch Object.
   const p = createPatchObject(20, 21)
   p.length1 = 18
+  p.byteLength1 = 18
   p.length2 = 17
+  p.byteLength2 = 17
   p.diffs = [
     [DIFF_EQUAL, 'jump'],
     [DIFF_DELETE, 's'],

--- a/src/patch/addPadding.ts
+++ b/src/patch/addPadding.ts
@@ -34,6 +34,8 @@ export function addPadding(patches: Patch[], margin: number = DEFAULT_MARGIN): s
     patch.start2 -= paddingLength // Should be 0.
     patch.length1 += paddingLength
     patch.length2 += paddingLength
+    patch.byteLength1 += paddingLength
+    patch.byteLength2 += paddingLength
   } else if (paddingLength > diffs[0][1].length) {
     // Grow first equality.
     const extraLength = paddingLength - diffs[0][1].length
@@ -42,6 +44,8 @@ export function addPadding(patches: Patch[], margin: number = DEFAULT_MARGIN): s
     patch.start2 -= extraLength
     patch.length1 += extraLength
     patch.length2 += extraLength
+    patch.byteLength1 += extraLength
+    patch.byteLength2 += extraLength
   }
 
   // Add some padding on end of last diff.
@@ -52,12 +56,16 @@ export function addPadding(patches: Patch[], margin: number = DEFAULT_MARGIN): s
     diffs.push([DIFF_EQUAL, nullPadding])
     patch.length1 += paddingLength
     patch.length2 += paddingLength
+    patch.byteLength1 += paddingLength
+    patch.byteLength2 += paddingLength
   } else if (paddingLength > diffs[diffs.length - 1][1].length) {
     // Grow last equality.
     const extraLength = paddingLength - diffs[diffs.length - 1][1].length
     diffs[diffs.length - 1][1] += nullPadding.substring(0, extraLength)
     patch.length1 += extraLength
     patch.length2 += extraLength
+    patch.byteLength1 += extraLength
+    patch.byteLength2 += extraLength
   }
 
   return nullPadding

--- a/src/patch/apply.ts
+++ b/src/patch/apply.ts
@@ -107,6 +107,7 @@ export function apply(
       results[x] = false
       // Subtract the delta for this failed patch from subsequent patches.
       delta -= parsed[x].length2 - parsed[x].length1
+      // @todo byte count?
     } else {
       // Found a match.  :)
       results[x] = true

--- a/src/patch/createPatchObject.ts
+++ b/src/patch/createPatchObject.ts
@@ -11,6 +11,8 @@ export interface Patch {
   start2: number
   length1: number
   length2: number
+  byteLength1: number
+  byteLength2: number
 }
 
 /**
@@ -50,5 +52,7 @@ export function createPatchObject(start1: number, start2: number): Patch {
     start2,
     length1: 0,
     length2: 0,
+    byteLength1: 0,
+    byteLength2: 0,
   }
 }

--- a/src/patch/splitMax.ts
+++ b/src/patch/splitMax.ts
@@ -1,5 +1,6 @@
 import {DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT} from '../diff/diff.js'
 import {diffText1, diffText2} from '../diff/diffText.js'
+import {countUtf8Bytes} from '../utils/utf8Indices.js'
 import {DEFAULT_MARGIN, MAX_BITS} from './constants.js'
 import {createPatchObject, type Patch} from './createPatchObject.js'
 
@@ -22,23 +23,28 @@ export function splitMax(patches: Patch[], margin: number = DEFAULT_MARGIN): voi
     patches.splice(x--, 1)
     let start1 = bigpatch.start1
     let start2 = bigpatch.start2
-    let precontext = ''
+    let preContext = ''
     while (bigpatch.diffs.length !== 0) {
       // Create one of several smaller patches.
-      const patch = createPatchObject(start1 - precontext.length, start2 - precontext.length)
+      const patch = createPatchObject(start1 - preContext.length, start2 - preContext.length)
       let empty = true
 
-      if (precontext !== '') {
-        patch.length1 = precontext.length
-        patch.length2 = precontext.length
-        patch.diffs.push([DIFF_EQUAL, precontext])
+      if (preContext !== '') {
+        const precontextByteCount = countUtf8Bytes(preContext)
+        patch.length1 = preContext.length
+        patch.byteLength1 = precontextByteCount
+        patch.length2 = preContext.length
+        patch.byteLength2 = precontextByteCount
+        patch.diffs.push([DIFF_EQUAL, preContext])
       }
       while (bigpatch.diffs.length !== 0 && patch.length1 < patchSize - margin) {
         const diffType = bigpatch.diffs[0][0]
         let diffText = bigpatch.diffs[0][1]
+        let diffTextByteCount = countUtf8Bytes(diffText)
         if (diffType === DIFF_INSERT) {
           // Insertions are harmless.
           patch.length2 += diffText.length
+          patch.byteLength2 += diffTextByteCount
           start2 += diffText.length
           const diff = bigpatch.diffs.shift()
           if (diff) {
@@ -53,6 +59,7 @@ export function splitMax(patches: Patch[], margin: number = DEFAULT_MARGIN): voi
         ) {
           // This is a large deletion.  Let it pass in one chunk.
           patch.length1 += diffText.length
+          patch.byteLength1 += diffTextByteCount
           start1 += diffText.length
           empty = false
           patch.diffs.push([diffType, diffText])
@@ -60,10 +67,13 @@ export function splitMax(patches: Patch[], margin: number = DEFAULT_MARGIN): voi
         } else {
           // Deletion or equality.  Only take as much as we can stomach.
           diffText = diffText.substring(0, patchSize - patch.length1 - margin)
+          diffTextByteCount = countUtf8Bytes(diffText)
           patch.length1 += diffText.length
+          patch.byteLength1 += diffTextByteCount
           start1 += diffText.length
           if (diffType === DIFF_EQUAL) {
             patch.length2 += diffText.length
+            patch.byteLength2 += diffTextByteCount
             start2 += diffText.length
           } else {
             empty = false
@@ -77,17 +87,20 @@ export function splitMax(patches: Patch[], margin: number = DEFAULT_MARGIN): voi
         }
       }
       // Compute the head context for the next patch.
-      precontext = diffText2(patch.diffs)
-      precontext = precontext.substring(precontext.length - margin)
+      preContext = diffText2(patch.diffs)
+      preContext = preContext.substring(preContext.length - margin)
       // Append the end context for this patch.
-      const postcontext = diffText1(bigpatch.diffs).substring(0, margin)
-      if (postcontext !== '') {
-        patch.length1 += postcontext.length
-        patch.length2 += postcontext.length
+      const postContext = diffText1(bigpatch.diffs).substring(0, margin)
+      const postContextByteCount = countUtf8Bytes(postContext)
+      if (postContext !== '') {
+        patch.length1 += postContext.length
+        patch.length2 += postContext.length
+        patch.byteLength1 += postContextByteCount
+        patch.byteLength2 += postContextByteCount
         if (patch.diffs.length !== 0 && patch.diffs[patch.diffs.length - 1][0] === DIFF_EQUAL) {
-          patch.diffs[patch.diffs.length - 1][1] += postcontext
+          patch.diffs[patch.diffs.length - 1][1] += postContext
         } else {
-          patch.diffs.push([DIFF_EQUAL, postcontext])
+          patch.diffs.push([DIFF_EQUAL, postContext])
         }
       }
       if (!empty) {

--- a/src/patch/stringify.ts
+++ b/src/patch/stringify.ts
@@ -20,24 +20,24 @@ export function stringify(patches: Patch[]): string {
  * @public
  */
 export function stringifyPatch(patch: Patch): string {
-  const {length1, length2, start1, start2, diffs} = patch
+  const {byteLength1, byteLength2, start1, start2, diffs} = patch
 
   let coords1: string
-  if (length1 === 0) {
+  if (byteLength1 === 0) {
     coords1 = `${start1},0`
-  } else if (length1 === 1) {
+  } else if (byteLength1 === 1) {
     coords1 = `${start1 + 1}`
   } else {
-    coords1 = `${start1 + 1},${length1}`
+    coords1 = `${start1 + 1},${byteLength1}`
   }
 
   let coords2: string
-  if (length2 === 0) {
+  if (byteLength2 === 0) {
     coords2 = `${start2},0`
-  } else if (length2 === 1) {
+  } else if (byteLength2 === 1) {
     coords2 = `${start2 + 1}`
   } else {
-    coords2 = `${start2 + 1},${length2}`
+    coords2 = `${start2 + 1},${byteLength2}`
   }
 
   const text = [`@@ -${coords1} +${coords2} @@\n`]

--- a/src/utils/utf8Indices.ts
+++ b/src/utils/utf8Indices.ts
@@ -45,6 +45,8 @@ export function adjustIndiciesToUtf8(patches: Patch[], base: string): Patch[] {
       start2: advanceTo(patch.start2),
       length1: patch.length1,
       length2: patch.length2,
+      byteLength1: patch.byteLength1,
+      byteLength2: patch.byteLength2,
     })
   }
 
@@ -97,6 +99,8 @@ export function adjustIndiciesToUcs2(patches: Patch[], base: string): Patch[] {
       start2: advanceTo(patch.start2),
       length1: patch.length1,
       length2: patch.length2,
+      byteLength1: patch.byteLength1,
+      byteLength2: patch.byteLength2,
     })
   }
 
@@ -109,4 +113,16 @@ function utf8len(codePoint: number): 1 | 2 | 3 | 4 {
   if (codePoint <= 0x07ff) return 2
   if (codePoint <= 0xffff) return 3
   return 4
+}
+
+export function countUtf8Bytes(str: string): number {
+  let bytes = 0
+  for (let i = 0; i < str.length; i++) {
+    const codePoint = str.codePointAt(i)
+    if (typeof codePoint === 'undefined') {
+      throw new Error('Failed to get codepoint')
+    }
+    bytes += utf8len(codePoint)
+  }
+  return bytes
 }


### PR DESCRIPTION
There may be a much easier approach here, but I'm not yet completely up to speed on how these diffs actually work and are represented - so don't be afraid to reject this approach quickly if I'm way off track.

Basically maintains separate `byteLength` counters alongside `length` on patches, and adjusts these every time the lengths are adjusted. It's not super elegant.

Very unsure about the parsing adjustments to `length` - previously these were just parsed straight from the patch, but now that they represent UTF8 bytes instead of characters, they need to be adjusted. I'm not sure if the approach of using the line text content and doing a delta between the the UTF8/UCS-2 versions is acceptable or if I'm really barking up the wrong tree there.

Let me know!