### PR TITLE
feat: export xIndex, add support for match options

### DIFF
--- a/src/diff/xIndex.ts
+++ b/src/diff/xIndex.ts
@@ -6,10 +6,11 @@ import {type Diff, DIFF_DELETE, DIFF_INSERT} from './diff.js'
  * e.g. 'The cat' vs 'The big cat', 1->1, 5->8
  *
  * @param diffs - Array of diff tuples.
- * @param loc - Location within textA.
+ * @param location - Location within textA.
  * @returns Location within textB.
+ * @public
  */
-export function xIndex(diffs: Diff[], loc: number): number {
+export function xIndex(diffs: Diff[], location: number): number {
   let chars1 = 0
   let chars2 = 0
   let lastChars1 = 0
@@ -24,7 +25,7 @@ export function xIndex(diffs: Diff[], loc: number): number {
       // Equality or insertion.
       chars2 += diffs[x][1].length
     }
-    if (chars1 > loc) {
+    if (chars1 > location) {
       // Overshot the location.
       break
     }
@@ -36,5 +37,5 @@ export function xIndex(diffs: Diff[], loc: number): number {
     return lastChars2
   }
   // Add the remaining character length.
-  return lastChars2 + (loc - lastChars1)
+  return lastChars2 + (location - lastChars1)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export {
 } from './diff/diff.js'
 
 // Match
-export {match} from './match/match.js'
+export {match, type MatchOptions} from './match/match.js'
 
 // Patch
 export {apply as applyPatches, type ApplyPatchOptions, type PatchResult} from './patch/apply.js'
@@ -22,3 +22,6 @@ export {stringifyPatch, stringify as stringifyPatches} from './patch/stringify.j
 
 // UCS-2 utils (beta)
 export {adjustIndiciesToUcs2, type AdjustmentOptions} from './utils/utf8Indices.js'
+
+// other utils
+export {xIndex} from './diff/xIndex.js'

--- a/src/match/bitap.ts
+++ b/src/match/bitap.ts
@@ -35,6 +35,7 @@ const MAX_BITS = 32
  * @param text - The text to search.
  * @param pattern - The pattern to search for.
  * @param loc - The location to search around.
+ * @param options - Options {@link BitapOptions}
  * @returns Best match index or -1.
  * @internal
  */

--- a/src/match/match.ts
+++ b/src/match/match.ts
@@ -1,15 +1,45 @@
 import {bitap} from './bitap.js'
 
 /**
+ * @public
+ */
+export interface MatchOptions {
+  /**
+   * At what point is no match declared (0.0 = perfection, 1.0 = very loose).
+   * The larger threshold is, the slower match() may take to compute
+   *
+   * Defaults to 0.5
+   */
+  threshold?: number
+
+  /**
+   * How far to search for a match (0 = exact location, 1000+ = broad match).
+   * A match this many characters away from the expected location will add
+   * 1.0 to the score (0.0 is a perfect match).
+   *
+   * The larger distance is, the slower match() may take to compute.
+   *
+   * Defaults to 1000.
+   */
+  distance?: number
+}
+
+/**
  * Locate the best instance of 'pattern' in 'text' near 'loc'.
  *
  * @param text - The text to search.
  * @param pattern - The pattern to search for.
  * @param searchLocation - The location to search around.
+ * @param options - Options {@link MatchOptions}
  * @returns Best match index or -1.
  * @public
  */
-export function match(text: string, pattern: string, searchLocation: number): number {
+export function match(
+  text: string,
+  pattern: string,
+  searchLocation: number,
+  options: MatchOptions = {},
+): number {
   // Check for null inputs.
   if (text === null || pattern === null || searchLocation === null) {
     throw new Error('Null input. (match())')
@@ -28,5 +58,5 @@ export function match(text: string, pattern: string, searchLocation: number): nu
   }
 
   // Do a fuzzy compare.
-  return bitap(text, pattern, loc)
+  return bitap(text, pattern, loc, options)
 }


### PR DESCRIPTION
This exports the `xIndex` utility as it can be useful on its own, e.g. to adjust a text position based on a diff.

- Also adds support for passing options (distance, threshold) to `match()`, which is later forwarded to `bitap()`. These used to be set as global variables in the original google/diff-match-patch.
- Also renamed a param for clarity (loc => location).