### PR TITLE
fix: add repo/homepage urls to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
     "posttest": "npm run lint",
     "prepublishOnly": "npm run build"
   },
+  "homepage": "https://github.com/sanity-io/diff-match-patch",
+  "repository": {
+    "url": "https://github.com/sanity-io/diff-match-patch"
+  },
   "keywords": [
     "diff",
     "diff-match-patch",


### PR DESCRIPTION
Just adding some metadata to make it easier to find the repo from npmjs.com 